### PR TITLE
Prevents install the tools more than once

### DIFF
--- a/lnx-helper-functions.sh
+++ b/lnx-helper-functions.sh
@@ -49,6 +49,38 @@ detect_vmware() {
     echo "VMware product version: $PRODUCT_VERSION"
 }
 
+# ----------------------------------------------------------------------
+# Function: check_vmware_tools_installed
+#   - Checks if the key VMware Tools files are already present in the script location
+#   - Echoes status message
+#   - Sets global variable CHECK_INSTALLED=1 if found, 0 otherwise
+# ----------------------------------------------------------------------
+check_vmware_tools_installed() {
+    CHECK_INSTALLED=0
+
+    # Get directory where the script is located
+    SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+    BACKUP_FOLDER="$SCRIPT_DIR/backup-linux"
+
+    echo "Checking for backup folder: $BACKUP_FOLDER"
+
+    if [ -d "$BACKUP_FOLDER" ]; then
+        CHECK_INSTALLED=1
+        echo ""
+        echo "VMware Tools backup folder found: backup-linux"
+        echo "Appears to be already present/installed."
+        echo "Skipping installation."
+        echo "Run lnx-uninstall.sh first to remove tools and restore original files."
+        echo ""
+        exit 1
+    else
+        echo "No backup-linux folder found in script directory."
+        echo "Proceeding with installation..."
+        echo ""
+    fi
+}
+
 # Check Python 3 interpreter
 check_python3() {
     PYVERSION="${PYVERSION:-python3}"
@@ -84,4 +116,19 @@ get_vmware_tools() {
     fi
 
     echo "Finished!"
+}
+
+# Function to Backup VMware files
+backup_vmware_files(){
+    echo "Creating backup-linux folder..."
+    rm -rf ./backup-linux
+    mkdir -p "./backup-linux"
+    cp -v /usr/lib/vmware/bin/vmware-vmx ./backup-linux/
+    cp -v /usr/lib/vmware/bin/vmware-vmx-debug ./backup-linux/
+    cp -v /usr/lib/vmware/bin/vmware-vmx-stats ./backup-linux/
+    if [ -d /usr/lib/vmware/lib/libvmwarebase.so.0/ ]; then
+        cp -v /usr/lib/vmware/lib/libvmwarebase.so.0/libvmwarebase.so.0 ./backup-linux/
+    elif [ -d /usr/lib/vmware/lib/libvmwarebase.so/ ]; then
+        cp -v /usr/lib/vmware/lib/libvmwarebase.so/libvmwarebase.so ./backup-linux/
+    fi
 }

--- a/lnx-install.sh
+++ b/lnx-install.sh
@@ -18,20 +18,14 @@ require_root
 # Detect VMware installation
 detect_vmware
 
-echo Creating backup-linux folder...
-rm -rf ./backup-linux
-mkdir -p "./backup-linux"
-cp -v /usr/lib/vmware/bin/vmware-vmx ./backup-linux/
-cp -v /usr/lib/vmware/bin/vmware-vmx-debug ./backup-linux/
-cp -v /usr/lib/vmware/bin/vmware-vmx-stats ./backup-linux/
-if [ -d /usr/lib/vmware/lib/libvmwarebase.so.0/ ]; then
-    cp -v /usr/lib/vmware/lib/libvmwarebase.so.0/libvmwarebase.so.0 ./backup-linux/
-elif [ -d /usr/lib/vmware/lib/libvmwarebase.so/ ]; then
-    cp -v /usr/lib/vmware/lib/libvmwarebase.so/libvmwarebase.so ./backup-linux/
-fi
-
 # Detect Python installation
 check_python3
+
+# Check if tools are already installed
+check_vmware_tools_installed
+
+# Backup VMware Files
+backup_vmware_files
 
 echo Patching...
 $PYVERSION ./unlocker.py

--- a/win-helper-functions.cmd
+++ b/win-helper-functions.cmd
@@ -65,6 +65,42 @@ if errorlevel 1 (
 endlocal & set "INSTALLPATH=%INSTALLPATH%" & set "VMWARE_INSTALLED=%VMWARE_INSTALLED%"
 goto :EOF
 
+:: ----------------------------------------------------------------------
+:: Function: Check if VMware Tools files are already present in INSTALLPATH
+:: Sets CHECK_INSTALLED=1 if files are found, otherwise 0
+:: Echoes status message
+:: ----------------------------------------------------------------------
+:check_vmware_tools_installed
+:: No setlocal - we want CHECK_INSTALLED visible in caller
+
+set "CHECK_INSTALLED=0"
+
+:: Get directory where the script is running
+set "SCRIPT_DIR=%~dp0"
+:: Remove trailing backslash if present
+if "%SCRIPT_DIR:~-1%"=="\" set "SCRIPT_DIR=%SCRIPT_DIR:~0,-1%"
+
+set "BACKUP_FOLDER=%SCRIPT_DIR%\backup-windows"
+
+echo Checking for backup folder: %BACKUP_FOLDER%
+
+if exist "%BACKUP_FOLDER%" (
+    set "CHECK_INSTALLED=1"
+    echo.
+    echo VMware Tools backup folder found: backup-windows
+    echo Appears to be already present/installed.
+    echo Skipping instalation.
+    echo Run win-uninstall.cmd first to remove tools and restore original files.
+    echo.
+) else (
+    echo No backup-windows folder found in script directory.
+    echo Proceeding with installation...
+    echo.
+)
+
+endlocal & set "CHECK_INSTALLED=%CHECK_INSTALLED%"
+goto :EOF
+
 :: --- Function: Copy VMware Tools ---
 :copy_vmware_tools
 if defined INSTALLPATH (

--- a/win-install.cmd
+++ b/win-install.cmd
@@ -24,6 +24,12 @@ if "%VMWARE_INSTALLED%" == "0" (
     exit /b
 )
 
+rem --- Check if tools are already installed ---
+call win-helper-functions.cmd check_vmware_tools_installed
+if "%CHECK_INSTALLED%"=="1" (
+    exit /b 0
+)
+
 pushd %~dp0
 
 echo.


### PR DESCRIPTION
Fixes #76

It prevents running the installation script more than once, avoiding patching an already patched installation by creating a backup folder with patched files instead of the original files. Subsequently, when running the uninstallation script, it would restore the patched files with the backup of patched files, making it no longer possible to restore the original files without reinstalling the VMware software.

Whenever there is a new version of the VMware software, it is advisable to first uninstall the VMware tools to restore the original files.

WARNING: Never delete the backup folders, otherwise it will be impossible to prevent the installation from running more than once, corrupting the backup folder of the original files again.