### PR TITLE
Change working directory to the batch file directory first

### DIFF
--- a/win-install.cmd
+++ b/win-install.cmd
@@ -1,5 +1,8 @@
 @echo off
 setlocal ENABLEEXTENSIONS
+
+pushd %~dp0
+
 echo.
 rem --- Get app version ---
 call win-helper-functions.cmd get_app_version
@@ -29,8 +32,6 @@ call win-helper-functions.cmd check_vmware_tools_installed
 if "%CHECK_INSTALLED%"=="1" (
     exit /b 0
 )
-
-pushd %~dp0
 
 echo.
 rem --- Stop VMware services ---

--- a/win-test-update-tools.cmd
+++ b/win-test-update-tools.cmd
@@ -1,6 +1,8 @@
 @echo off
 setlocal ENABLEEXTENSIONS
 
+pushd %~dp0
+
 rem --- Get app version ---
 call win-helper-functions.cmd get_app_version
 echo Get macOS VMware Tools %APPVERSION%
@@ -13,8 +15,6 @@ if "%IS_ADMIN%"=="0" (
     echo Administrator privileges required!
     exit /b 1
 )
-
-pushd %~dp0
 
 rem --- Detect VMware installation ---
 call win-helper-functions.cmd detect_vmware

--- a/win-uninstall.cmd
+++ b/win-uninstall.cmd
@@ -1,5 +1,8 @@
 @echo off
 setlocal ENABLEEXTENSIONS
+
+pushd %~dp0
+
 echo.
 rem --- Get app version ---
 call win-helper-functions.cmd get_app_version
@@ -20,8 +23,6 @@ call win-helper-functions.cmd detect_vmware
 if "%VMWARE_INSTALLED%" == "0" (
     exit /b
 )
-
-pushd %~dp0
 
 echo.
 rem --- Stop VMware services ---

--- a/win-update-tools.cmd
+++ b/win-update-tools.cmd
@@ -1,6 +1,8 @@
 @echo off
 setlocal ENABLEEXTENSIONS
 
+pushd %~dp0
+
 rem --- Get app version ---
 call win-helper-functions.cmd get_app_version
 echo Get macOS VMware Tools %APPVERSION%
@@ -13,8 +15,6 @@ if "%IS_ADMIN%"=="0" (
     echo Administrator privileges required!
     exit /b 1
 )
-
-pushd %~dp0
 
 rem --- Detect VMware installation ---
 call win-helper-functions.cmd detect_vmware


### PR DESCRIPTION
Hi!

In #75 we have errors like this when running "win-....cmd" scripts with ADMIN rights:

```
'win-helper-functions.cmd' is not recognized as an internal or external command,
operable program or batch file.
Unlocker  for VMware Workstation
=====================================

```

That's because the `pushd %~dp0` didn't at the beginning of the scripts.

Here is the fix.

<br>

Thank you for maintaining this repository for nearly 7 years.

