### PR TITLE
Kill also "vmware.exe" to free "vmwarebase.dll"

### DIFF
--- a/win-helper-functions.cmd
+++ b/win-helper-functions.cmd
@@ -124,6 +124,7 @@ net stop VMwareHostd            >NUL 2>&1
 net stop VMAuthdService         >NUL 2>&1
 net stop VMUSBArbService        >NUL 2>&1
 taskkill /F /IM vmware-tray.exe >NUL 2>&1
+taskkill /F /IM vmware.exe      >NUL 2>&1
 goto :EOF
 
 :: --- Function: Start VMware services ---


### PR DESCRIPTION
Hello.

In #75 we have errors like this when running scripts with Admin rights:

```
GOS Patching: C:\Program Files\VMware\VMware Workstation\vmwarebase.dll
Traceback (most recent call last):
  File "unlocker.py", line 392, in <module>
  File "unlocker.py", line 388, in main
  File "unlocker.py", line 298, in patchbase
PermissionError: [Errno 13] Permission denied: 'C:\\Program Files\\VMware\\VMware Workstation\\vmwarebase.dll'
[PYI-12220:ERROR] Failed to execute script 'unlocker' due to unhandled exception!

```

That's because the "vmwarebase.dll" file might be being used by VMware Workstation GUI ("vmware.exe"), too. Here is a screenshot of MS' Process Explorer:

<img width="400" alt="screenshot of Process Explorer with showing processes which are using 'vmwarebase.dll'" src="https://github.com/user-attachments/assets/f48ef1da-5699-403c-9c54-40727eed64cb" />

Here is the fix.

<br>

Commit message:

```
Kill also "vmware.exe" to free "vmwarebase.dll"

I don't totally agree to use/abuse the flag "/F", but I don't know if a
  normal kill can be ignored by the process in any case, so, I follow.

```

.